### PR TITLE
:bug: :notebook: add missing sub inline documentation to close #4

### DIFF
--- a/src/promo-node-utils.ts
+++ b/src/promo-node-utils.ts
@@ -42,6 +42,10 @@ interface PromoAccessTokenJwt {
  * @param appId the string appId from the tincre.dev dashboard
  * @param clientSecret the string clientSecret from the tincre.dev dashboard
  * @param expiration optional expiration number in seconds; defaults to 30 min
+ * @param sub optional subject string client email; defaults to nothing which
+ *   gives the scope parameter when validated within the Promo API a value of
+ *   'userRW'. If an email is included, it is checked against the emails within
+ *   the permissions tokens available.
  * @returns string JWT signed with the clientSecret provided
  */
 function generateAccessToken(


### PR DESCRIPTION
Closes [#4](https://gitlab.com/tincre/promo-button-node/-/issues/4) which outlines missing inline documentation for the `generateAccessToken` function.