### PR TITLE
:wrench: update test node to 18

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ stages:
 - test
 unit-test:
   stage: unit-test
-  image: node:16
+  image: node:18
   tags:
   - cicd
   - test


### PR DESCRIPTION
This updates the node version from 16 to 18 in the test runner for Gitlab CICD.